### PR TITLE
Fix page selection reload bug

### DIFF
--- a/projects/vue-project/src/app/pages/overview/overview.page.vue
+++ b/projects/vue-project/src/app/pages/overview/overview.page.vue
@@ -26,9 +26,11 @@ const racialTraits = ref([]);
 const unsubscribeRouterQueryParams = useRouter().afterEach((to) => updatePagination(to.query));
 
 onBeforeMount(async () => {
-    updatePagination(useRoute().query);
+    const queryParams = useRoute().query;
 
     await raceStore.initialize();
+
+    updatePagination(queryParams);
 
     racialTraits.value = raceStore.getAllTraits;
     races.value = raceStore.getFilteredRaces;


### PR DESCRIPTION
Upon reload the incorrect page would be selected which happened because the query params were read in too early